### PR TITLE
feat: add task categories

### DIFF
--- a/app/app.vue
+++ b/app/app.vue
@@ -2,25 +2,27 @@
   <div class="min-h-screen bg-gray-50 text-gray-900 font-sans">
     <div class="flex min-h-screen">
       <aside class="w-72 p-4 border-r flex flex-col justify-between">
-        <h1 class="flex items-center gap-2 text-lg font-bold">
-          <span class="material-symbols-outlined text-brand">checklist</span> Todo
-        </h1>
-        <div class="mt-4 space-y-2 h-[300px]">
-          <DatePicker
-            class="inline-picker"
-            v-model="day"
-            type="date"
-            format="YYYY-MM-DD"
-            value-type="format"
-            :open="true"
-            :editable="false"
-            :clearable="false"
-            :append-to-body="false"
-            title-format="YYYY-MM-DD"
-            @change="onDateSelect"
-          />
+        <div>
+          <h1 class="flex items-center gap-2 text-lg font-bold">
+            <span class="material-symbols-outlined text-brand">checklist</span> Todo
+          </h1>
+          <div class="space-y-2 h-[300px]">
+            <DatePicker
+              class="inline-picker"
+              v-model="day"
+              type="date"
+              format="YYYY-MM-DD"
+              value-type="format"
+              :open="true"
+              :editable="false"
+              :clearable="false"
+              :append-to-body="false"
+              title-format="YYYY-MM-DD"
+              @change="onDateSelect"
+            />
+          </div>
+          <CategoryList />
         </div>
-        <CategoryList />
         <AuthBlock />
       </aside>
       <main class="flex-1 p-6">

--- a/app/app.vue
+++ b/app/app.vue
@@ -20,6 +20,7 @@
             @change="onDateSelect"
           />
         </div>
+        <CategoryList />
         <AuthBlock />
       </aside>
       <main class="flex-1 p-6">
@@ -33,6 +34,7 @@
 import { useRouter } from 'vue-router'
 import DatePicker from 'vue-datepicker-next'
 import 'vue-datepicker-next/index.css'
+import CategoryList from './components/CategoryList.vue'
 
 const router = useRouter()
 const day = useState('day', () =>
@@ -50,7 +52,8 @@ const onDateSelect = (newDate: string | Date) => {
   display: none !important;
 }
 
-/* Todo: в будущем так будут выделяться дни где все задачи выполнены, а и другим цветом где остались не выполненые задачи.
+/* Todo: in the future days with all tasks completed will be highlighted like this
+and a different color will mark days with remaining tasks.
 .cell[title="2025-08-09"] {
   background: green;
   color: white;

--- a/app/assets/css/tailwind.css
+++ b/app/assets/css/tailwind.css
@@ -2,4 +2,4 @@
 @tailwind components;
 @tailwind utilities;
 
-:root { --brand:#10b981; } /* тема по умолчанию */
+:root { --brand:#10b981; } /* default theme */

--- a/app/components/AuthBlock.vue
+++ b/app/components/AuthBlock.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="flex items-center gap-2">
+  <div class="flex items-center gap-2 mt-4">
     <template v-if="user">
       <img :src="user.photoURL || ''" class="w-6 h-6 rounded-full" />
       <span class="text-sm">{{ user.displayName || 'User' }}</span>

--- a/app/components/CategoryList.vue
+++ b/app/components/CategoryList.vue
@@ -1,0 +1,81 @@
+<template>
+  <div>
+    <h3 class="text-lg font-bold mt-4 flex items-center gap-1">
+      <span class="material-symbols-outlined">label</span>Categories
+    </h3>
+    <ul class="mt-2 space-y-1">
+      <li v-for="c in categories" :key="c.id">
+        <span
+          class="px-2 py-1 rounded text-sm flex items-center gap-1 text-white"
+          :style="{ background: c.background }"
+        >
+          <span v-if="c.icon" class="material-symbols-outlined">{{ c.icon }}</span>
+          {{ c.title }}
+        </span>
+      </li>
+    </ul>
+    <button
+      @click="addCategory"
+      class="mt-2 bg-brand text-white px-3 py-1 rounded w-full"
+    >
+      Add category
+    </button>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { watch, onUnmounted } from 'vue'
+import { useFirebaseApp } from 'vuefire'
+import { getFirestore, collection, addDoc, onSnapshot } from 'firebase/firestore'
+
+interface Category {
+  id?: string
+  title: string
+  icon: string
+  background: string
+}
+
+const user = useState<{ uid: string } | null>('user', () => null)
+const categories = useState<Category[]>('categories', () => [])
+
+const app = useFirebaseApp()
+const db = getFirestore(app)
+
+let off: (() => void) | null = null
+
+watch(user, (u) => {
+  if (off) {
+    off()
+    off = null
+  }
+  if (u) {
+    const q = collection(db, 'users', u.uid, 'categories')
+    off = onSnapshot(q, (snap) => {
+      categories.value = snap.docs.map((d) => ({
+        id: d.id,
+        ...(d.data() as Omit<Category, 'id'>)
+      }))
+    })
+  } else {
+    categories.value = []
+  }
+}, { immediate: true })
+
+onUnmounted(() => {
+  if (off) off()
+})
+
+const addCategory = async () => {
+  if (!user.value) return
+  const title = prompt('Category name?')?.trim()
+  if (!title) return
+  const icon = prompt('Icon (material icon)?')?.trim() || ''
+  const background =
+    prompt('Background color (e.g., #ff0000)?')?.trim() || '#000000'
+  await addDoc(collection(db, 'users', user.value.uid, 'categories'), {
+    title,
+    icon,
+    background
+  })
+}
+</script>

--- a/app/components/CategoryList.vue
+++ b/app/components/CategoryList.vue
@@ -32,18 +32,38 @@
             placeholder="Title"
             class="border rounded w-full px-2 py-1"
           />
-          <input
-            v-model="newCategory.icon"
-            placeholder="Icon"
-            class="border rounded w-full px-2 py-1"
-          />
+          <div>
+            <span class="block text-sm mb-1">Icon</span>
+            <div class="grid grid-cols-5 gap-2">
+              <button
+                v-for="icon in iconOptions"
+                :key="icon"
+                type="button"
+                @click="newCategory.icon = icon"
+                :class="[
+                  'p-2 border rounded flex items-center justify-center',
+                  newCategory.icon === icon ? 'bg-brand text-white' : 'bg-gray-100'
+                ]"
+              >
+                <span class="material-symbols-outlined">{{ icon }}</span>
+              </button>
+            </div>
+          </div>
           <div>
             <span class="block text-sm mb-1">Background</span>
-            <input
-              v-model="newCategory.background"
-              type="color"
-              class="w-full h-10 border rounded"
-            />
+            <div class="grid grid-cols-6 gap-2">
+              <button
+                v-for="color in colorOptions"
+                :key="color"
+                type="button"
+                @click="newCategory.background = color"
+                :style="{ background: color }"
+                :class="[
+                  'w-8 h-8 rounded',
+                  newCategory.background === color ? 'ring-2 ring-offset-2 ring-brand' : ''
+                ]"
+              ></button>
+            </div>
           </div>
         </div>
         <div class="mt-4 flex justify-end gap-2">
@@ -102,10 +122,31 @@ onUnmounted(() => {
 })
 
 const showModal = ref(false)
+const iconOptions = [
+  'home',
+  'stadia_controller',
+  'work',
+  'key',
+  'person',
+  'person_book',
+  'shopping_basket',
+  'shopping_cart',
+  'movie'
+]
+
+const colorOptions = [
+  '#87CEFA',
+  '#90EE90',
+  '#800000',
+  '#FFA500',
+  '#808080',
+  '#A52A2A'
+]
+
 const newCategory = reactive({
   title: '',
-  icon: '',
-  background: '#000000'
+  icon: iconOptions[0],
+  background: colorOptions[0]
 })
 
 const openModal = () => {
@@ -127,8 +168,8 @@ const saveCategory = async () => {
     background: newCategory.background
   })
   newCategory.title = ''
-  newCategory.icon = ''
-  newCategory.background = '#000000'
+  newCategory.icon = iconOptions[0]
+  newCategory.background = colorOptions[0]
   showModal.value = false
 }
 </script>

--- a/app/components/CategoryList.vue
+++ b/app/components/CategoryList.vue
@@ -15,16 +15,52 @@
       </li>
     </ul>
     <button
-      @click="addCategory"
+      @click="openModal"
       class="mt-2 bg-brand text-white px-3 py-1 rounded w-full"
     >
       Add category
     </button>
+    <div
+      v-if="showModal"
+      class="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center"
+    >
+      <div class="bg-white p-4 rounded shadow w-80">
+        <h4 class="text-lg font-semibold mb-2">New category</h4>
+        <div class="space-y-2">
+          <input
+            v-model="newCategory.title"
+            placeholder="Title"
+            class="border rounded w-full px-2 py-1"
+          />
+          <input
+            v-model="newCategory.icon"
+            placeholder="Icon"
+            class="border rounded w-full px-2 py-1"
+          />
+          <div>
+            <span class="block text-sm mb-1">Background</span>
+            <input
+              v-model="newCategory.background"
+              type="color"
+              class="w-full h-10 border rounded"
+            />
+          </div>
+        </div>
+        <div class="mt-4 flex justify-end gap-2">
+          <button @click="closeModal" class="px-3 py-1 bg-gray-200 rounded">
+            Cancel
+          </button>
+          <button @click="saveCategory" class="px-3 py-1 bg-brand text-white rounded">
+            Save
+          </button>
+        </div>
+      </div>
+    </div>
   </div>
 </template>
 
 <script setup lang="ts">
-import { watch, onUnmounted } from 'vue'
+import { watch, onUnmounted, ref, reactive } from 'vue'
 import { useFirebaseApp } from 'vuefire'
 import { getFirestore, collection, addDoc, onSnapshot } from 'firebase/firestore'
 
@@ -65,17 +101,34 @@ onUnmounted(() => {
   if (off) off()
 })
 
-const addCategory = async () => {
+const showModal = ref(false)
+const newCategory = reactive({
+  title: '',
+  icon: '',
+  background: '#000000'
+})
+
+const openModal = () => {
   if (!user.value) return
-  const title = prompt('Category name?')?.trim()
+  showModal.value = true
+}
+
+const closeModal = () => {
+  showModal.value = false
+}
+
+const saveCategory = async () => {
+  if (!user.value) return
+  const title = newCategory.title.trim()
   if (!title) return
-  const icon = prompt('Icon (material icon)?')?.trim() || ''
-  const background =
-    prompt('Background color (e.g., #ff0000)?')?.trim() || '#000000'
   await addDoc(collection(db, 'users', user.value.uid, 'categories'), {
     title,
-    icon,
-    background
+    icon: newCategory.icon.trim(),
+    background: newCategory.background
   })
+  newCategory.title = ''
+  newCategory.icon = ''
+  newCategory.background = '#000000'
+  showModal.value = false
 }
 </script>

--- a/app/components/CategoryList.vue
+++ b/app/components/CategoryList.vue
@@ -1,13 +1,13 @@
 <template>
   <div>
-    <h3 class="text-lg font-bold mt-4 flex items-center gap-1">
+    <h3 class="font-bold mt-2 flex items-center gap-1">
       <span class="material-symbols-outlined">label</span>Categories
     </h3>
     <ul class="mt-2 space-y-1">
       <li v-for="c in categories" :key="c.id">
         <span
-          class="px-2 py-1 rounded text-sm flex items-center gap-1 text-white"
-          :style="{ background: c.background }"
+          class="px-2 py-1 rounded text-sm flex items-center gap-1"
+          :style="{ background: c.background, color: textColor(c.background) }"
         >
           <span v-if="c.icon" class="material-symbols-outlined">{{ c.icon }}</span>
           {{ c.title }}
@@ -18,11 +18,11 @@
       @click="openModal"
       class="mt-2 bg-brand text-white px-3 py-1 rounded w-full"
     >
-      Add category
+      + Add category
     </button>
     <div
       v-if="showModal"
-      class="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center"
+      class="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-[3000]"
     >
       <div class="bg-white p-4 rounded shadow w-80">
         <h4 class="text-lg font-semibold mb-2">New category</h4>
@@ -131,15 +131,22 @@ const iconOptions = [
   'person_book',
   'shopping_basket',
   'shopping_cart',
-  'movie'
+  'movie',
+  'exercise'
 ]
 
 const colorOptions = [
+  '#F9FAFB',
   '#87CEFA',
   '#90EE90',
   '#800000',
   '#FFA500',
   '#808080',
+  '#F9DF1D',
+  '#D0D0D0',
+  '#3F51B5',
+  '#607D8B',
+  '#009688',
   '#A52A2A'
 ]
 
@@ -164,12 +171,34 @@ const saveCategory = async () => {
   if (!title) return
   await addDoc(collection(db, 'users', user.value.uid, 'categories'), {
     title,
-    icon: newCategory.icon.trim(),
+    icon: newCategory.icon?.trim(),
     background: newCategory.background
   })
   newCategory.title = ''
   newCategory.icon = iconOptions[0]
   newCategory.background = colorOptions[0]
   showModal.value = false
+}
+
+function textColor(bg: string) {
+  const { r, g, b } = toRGB(bg);
+  const L = (0.2126 * r + 0.7152 * g + 0.0722 * b) / 255;
+  return L > 0.6 ? '#111827' : '#ffffff';
+}
+
+function toRGB(color: string) {
+  if (!color) return { r: 0, g: 0, b: 0 };
+  if (color.startsWith('#')) {
+    let hex = color.slice(1);
+    if (hex.length === 3) hex = hex.split('').map(c => c + c).join('');
+    const num = parseInt(hex, 16);
+    return { r: (num >> 16) & 255, g: (num >> 8) & 255, b: num & 255 };
+  }
+  
+  const m = color.match(/rgba?\((\d+),\s*(\d+),\s*(\d+)/i);
+  if (m && m.length >= 4) {
+    return { r: Number(m[1]), g: Number(m[2]), b: Number(m[3]) };
+  }
+  return { r: 0, g: 0, b: 0 };
 }
 </script>

--- a/app/components/TodoList.vue
+++ b/app/components/TodoList.vue
@@ -31,17 +31,17 @@
             <span :class="{ 'line-through text-gray-400': t.done }">{{ t.title }}</span>
           </label>
           <span
-            v-if="categoryMap[t.categoryId]"
+            v-if="categoryMap[t.categoryId || '']"
             class="text-xs px-2 py-1 rounded text-white flex items-center gap-1"
-            :style="{ background: categoryMap[t.categoryId].background }"
+            :style="{ background: categoryMap[t.categoryId || '']?.background }"
           >
             <span
-              v-if="categoryMap[t.categoryId].icon"
+              v-if="categoryMap[t.categoryId || '']?.icon"
               class="material-symbols-outlined"
             >
-              {{ categoryMap[t.categoryId].icon }}
+              {{ categoryMap[t.categoryId || '']?.icon }}
             </span>
-            {{ categoryMap[t.categoryId].title }}
+            {{ categoryMap[t.categoryId || '']?.title }}
           </span>
           <button class="text-red-500" @click="deleteTask(i)" aria-label="Remove task">
             <span class="material-symbols-outlined">delete</span>


### PR DESCRIPTION
## Summary
- add category management component to sidebar
- allow tasks to be tagged with user-specific categories
- translate category UI text to English

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689aefdc5914832e9ed36ee6e9c75782