### PR TITLE
Highlight DatePicker days based on tasks

### DIFF
--- a/app/app.vue
+++ b/app/app.vue
@@ -34,7 +34,7 @@
 </template>
 
 <script setup lang="ts">
-import { useRouter } from 'vue-router'
+import { useRouter, useRoute } from 'vue-router'
 import { computed } from 'vue'
 import DatePicker from 'vue-datepicker-next'
 import 'vue-datepicker-next/index.css'
@@ -47,6 +47,7 @@ interface Todo {
 }
 
 const router = useRouter()
+const route = useRoute()
 const day = useState('day', () =>
   new Date().toISOString().slice(0, 10)
 )
@@ -62,9 +63,10 @@ const dayMap = computed(() => {
   return map
 })
 
-const getDayClass = (value: Date, innerValue: Date[], classes: string) => {
+const getDayClass = (value: Date, _innerValue: Date[], classes: string) => {
   const date = format(value, 'yyyy-MM-dd')
-  if (innerValue.some(v => format(v, 'yyyy-MM-dd') === date)) {
+  const selected = route.params.date as string | undefined
+  if (selected === date) {
     return `${classes} selected-day`
   }
   const info = dayMap.value[date]

--- a/app/app.vue
+++ b/app/app.vue
@@ -84,21 +84,29 @@ const onDateSelect = (newDate: string | Date) => {
 <style>
 .inline-picker .mx-input-wrapper,
 .inline-picker .mx-input {
-  display: none !important;
+  display: none;
+}
+
+.mx-datepicker-main {
+  border-radius: 5px;
+}
+
+.mx-datepicker .cell {
+  border-radius: 3px;
 }
 
 .mx-datepicker .cell.completed-day {
-  background: #22c55e !important;
-  color: #ffffff !important;
+  background: #22c55e;
+  color: #ffffff;
 }
 
 .mx-datepicker .cell.pending-day {
-  background: #6b7280 !important;
-  color: #ffffff !important;
+  background: #6b7280;
+  color: #ffffff;
 }
 
 .mx-datepicker .cell.selected-day {
-  background: #3b82f6 !important;
-  color: #ffffff !important;
+  background: #3b82f6;
+  color: #ffffff;
 }
 </style>

--- a/app/components/TodoList.vue
+++ b/app/components/TodoList.vue
@@ -91,7 +91,7 @@ const categories = useState<Category[]>('categories', () => [])
 const app = useFirebaseApp()
 const db = getFirestore(app)
 
-const tasks = ref<Todo[]>([])
+const tasks = useState<Todo[]>('tasks', () => [])
 const month = computed(() => day.value.slice(0, 7))
 let off: (() => void) | null = null
 


### PR DESCRIPTION
## Summary
- Share tasks state globally for calendar access
- Highlight calendar days: blue for selected, green for complete, gray for pending
- Style datepicker cells for clarity

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_689b13ea3a8c832ea53946ab15893c7f