### PR TITLE
feat: show selected category context in UI

### DIFF
--- a/app/app.vue
+++ b/app/app.vue
@@ -26,7 +26,10 @@
         </div>
         <AuthBlock />
       </aside>
-      <main class="flex-1 p-6">
+      <main
+        class="flex-1 p-6"
+        :style="{ background: activeCategory?.background || undefined }"
+      >
         <NuxtPage />
       </main>
     </div>
@@ -52,6 +55,12 @@ const day = useState('day', () =>
   new Date().toISOString().slice(0, 10)
 )
 const tasks = useState<Todo[]>('tasks', () => [])
+const categories = useState<{ id: string; background: string }[]>('categories', () => [])
+const activeCategoryId = useState<string>('activeCategoryId', () => '')
+
+const activeCategory = computed(() =>
+  categories.value.find((c) => c.id === activeCategoryId.value)
+)
 
 const dayMap = computed(() => {
   const map: Record<string, { total: number; done: number }> = {}

--- a/app/components/CategoryList.vue
+++ b/app/components/CategoryList.vue
@@ -1,24 +1,24 @@
 <template>
   <div>
-    <h3 class="font-bold mt-2 flex items-center gap-1">
+    <h3 class="mt-2 flex items-center gap-1">
       <span class="material-symbols-outlined">label</span>Categories
     </h3>
     <ul class="mt-2 space-y-1">
       <li v-for="c in categories" :key="c.id" class="flex items-center gap-1">
+        <span class="material-symbols-outlined" :class="{'invisible': activeCategoryId !== c.id}">check</span>
         <span
           class="px-2 py-1 rounded text-sm flex items-center gap-1 cursor-pointer flex-1"
-          :class="{ 'ring-2 ring-brand': activeCategoryId === c.id }"
           :style="{ background: c.background, color: textColor(c.background) }"
           @click="toggleFilter(c.id)"
         >
           <span v-if="c.icon" class="material-symbols-outlined">{{ c.icon }}</span>
           {{ c.title }}
         </span>
-        <button @click="openModal(c)" class="text-gray-500" aria-label="Edit category">
-          <span class="material-symbols-outlined text-sm">edit</span>
+        <button @click="openModal(c)" class="bg-gray-50 rounded text-black" aria-label="Edit category" title="Edit category">
+          <span class="material-symbols-outlined text-sm p-1.5">edit</span>
         </button>
-        <button @click="confirmDelete(c)" class="text-red-500" aria-label="Delete category">
-          <span class="material-symbols-outlined text-sm">delete</span>
+        <button @click="confirmDelete(c)" class="bg-red-500 rounded" aria-label="Delete category" title="Delete category">
+          <span class="material-symbols-outlined text-sm p-1.5">delete</span>
         </button>
       </li>
     </ul>

--- a/app/components/TodoList.vue
+++ b/app/components/TodoList.vue
@@ -1,8 +1,9 @@
 <template>
   <div class="max-w-3xl">
-    <h2 class="text-2xl font-bold mb-4 flex items-center gap-1">
+    <h2 class="text-2xl font-bold mb-4 flex items-center gap-1"
+      :style="{ color: activeCategory?.background? textColor(activeCategory?.background) : '' }">
       <span
-        class="material-symbols-outlined"
+        class="material-symbols-outlined text-4xl"
         v-if="activeCategory?.icon"
         >{{ activeCategory.icon }}</span
       >
@@ -187,5 +188,23 @@ const toggle = async (i: number) => {
   if (t?.id) await updateDoc(doc(db, 'users', user.value.uid, 'todos', t.id), {
     done: !t.done
   })
+}
+
+function textColor(bg: string) {
+  const { r, g, b } = toRGB(bg);
+  const L = (0.2126 * r + 0.7152 * g + 0.0722 * b) / 255;
+  return L > 0.6 ? '#111827' : '#ffffff';
+}
+
+function toRGB(color: string) {
+  if (!color) return { r: 0, g: 0, b: 0 };
+  if (color.startsWith('#')) {
+    const hex = color.slice(1).replace(/^(.)(.)(.)$/, '$1$1$2$2$3$3');
+    const num = parseInt(hex, 16);
+    return { r: (num >> 16) & 255, g: (num >> 8) & 255, b: num & 255 };
+  }
+
+  const m = color.match(/\d+/g);
+  return m ? { r: +m[0], g: +Number(m[1]), b: +Number(m[2]) } : { r: 0, g: 0, b: 0 };
 }
 </script>

--- a/app/components/TodoList.vue
+++ b/app/components/TodoList.vue
@@ -1,7 +1,13 @@
 <template>
   <div class="max-w-3xl">
     <h2 class="text-2xl font-bold mb-4 flex items-center gap-1">
-      <span class="material-symbols-outlined">checklist</span>ToDo
+      <span
+        class="material-symbols-outlined"
+        v-if="activeCategory?.icon"
+        >{{ activeCategory.icon }}</span
+      >
+      <span v-else class="material-symbols-outlined">checklist</span>
+      {{ activeCategory?.title || 'ToDo' }}
     </h2>
     <div class="space-y-2">
       <div class="flex gap-2">
@@ -88,6 +94,10 @@ const day = useState('day', () => new Date().toISOString().slice(0, 10))
 const user = useState<{ uid: string } | null>('user', () => null)
 const categories = useState<Category[]>('categories', () => [])
 const activeCategoryId = useState<string>('activeCategoryId', () => '')
+
+const activeCategory = computed(() =>
+  categories.value.find((c) => c.id === activeCategoryId.value)
+)
 
 const app = useFirebaseApp()
 const db = getFirestore(app)


### PR DESCRIPTION
## Summary
- change main background color to match selected category
- show selected category icon and name in todo header

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_689b1dea19d0832e93f569b0c1518708