### PR TITLE
Default category selection for new tasks

### DIFF
--- a/app/components/TodoList.vue
+++ b/app/components/TodoList.vue
@@ -116,6 +116,11 @@ const categoryMap = computed<Record<string, Category>>(() => {
   return map
 })
 
+watch(activeCategoryId, id => {
+  categoryId.value = id
+}, { immediate: true })
+
+
 const loadMonth = (m: string) => {
   if (!user.value) return
   const start = format(startOfMonth(new Date(m + '-01')), 'yyyy-MM-dd')
@@ -173,7 +178,7 @@ const add = async () => {
     categoryId: categoryId.value || null
   })
   title.value = ''
-  categoryId.value = ''
+  categoryId.value = activeCategoryId.value
 }
 
 const deleteTask = async (i: number) => {


### PR DESCRIPTION
## Summary
- Sync task creation category with the active category
- Keep selected category after adding a task

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689b2662416c832e9d63cecaef51b9f1