### PR TITLE
feat: allow editing todo items

### DIFF
--- a/app/components/CategoryList.vue
+++ b/app/components/CategoryList.vue
@@ -32,7 +32,7 @@
       v-if="showModal"
       class="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-[3000]"
     >
-      <div class="bg-white p-4 rounded shadow w-80">
+      <div class="bg-white p-4 rounded shadow w-80 text-black">
         <h4 class="text-lg font-semibold mb-2">
           {{ editingId ? 'Edit category' : 'New category' }}
         </h4>

--- a/app/components/TodoList.vue
+++ b/app/components/TodoList.vue
@@ -58,7 +58,7 @@
                 {{ categoryMap[t.categoryId]?.title }}
               </span>
 
-              <button class="text-blue-500" @click="openEdit(i)" aria-label="Edit task">
+              <button @click="openEdit(i)" aria-label="Edit task">
                 <span class="material-symbols-outlined">edit</span>
               </button>
               <button class="text-red-500" @click="deleteTask(i)" aria-label="Remove task">
@@ -225,6 +225,7 @@ const editCategoryId = ref('')
 
 const openEdit = (i: number) => {
   const t = list.value[i]
+  if (!t) return
   editIndex.value = i
   editTitle.value = t.title
   editCategoryId.value = t.categoryId || ''
@@ -239,12 +240,14 @@ const closeEdit = () => {
 const saveEdit = async () => {
   if (editIndex.value === null || !user.value) return
   const t = list.value[editIndex.value]
+  const title = editTitle.value.trim()
+  const categoryId = editCategoryId.value || null
+  closeEdit()
   if (t?.id)
     await updateDoc(doc(db, 'users', user.value.uid, 'todos', t.id), {
-      title: editTitle.value.trim(),
-      categoryId: editCategoryId.value || null,
+      title,
+      categoryId,
     })
-  closeEdit()
 }
 
 const add = async () => {

--- a/app/components/TodoList.vue
+++ b/app/components/TodoList.vue
@@ -52,12 +52,15 @@
                 class="text-xs px-2 py-1 rounded flex items-center gap-1"
                 :style="{ background: categoryMap[t.categoryId]?.background, color: textColor(categoryMap[t.categoryId]?.background || '') }"
               >
-                <span v-if="categoryMap[t.categoryId]?.icon" class="material-symbols-outlined">
+              <span v-if="categoryMap[t.categoryId]?.icon" class="material-symbols-outlined">
                   {{ categoryMap[t.categoryId]?.icon }}
                 </span>
                 {{ categoryMap[t.categoryId]?.title }}
               </span>
 
+              <button class="text-blue-500" @click="openEdit(i)" aria-label="Edit task">
+                <span class="material-symbols-outlined">edit</span>
+              </button>
               <button class="text-red-500" @click="deleteTask(i)" aria-label="Remove task">
                 <span class="material-symbols-outlined">delete</span>
               </button>
@@ -65,6 +68,35 @@
           </li>
         </template>
       </draggable>
+    </div>
+    <div
+      v-if="editIndex !== null"
+      class="fixed inset-0 bg-black/50 flex items-center justify-center"
+    >
+      <div class="bg-white p-6 rounded shadow max-w-sm w-full">
+        <h3 class="text-lg font-bold mb-4">Edit task</h3>
+        <input
+          v-model="editTitle"
+          class="border rounded px-3 py-2 w-full mb-2"
+        />
+        <select
+          v-model="editCategoryId"
+          class="border rounded px-3 py-2 w-full mb-4"
+        >
+          <option value="">No category</option>
+          <option v-for="c in categories" :key="c.id" :value="c.id">
+            {{ c.title }}
+          </option>
+        </select>
+        <div class="flex justify-end gap-2">
+          <button @click="closeEdit" class="px-4 py-2 rounded border">
+            Cancel
+          </button>
+          <button @click="saveEdit" class="bg-brand text-white px-4 py-2 rounded">
+            Save
+          </button>
+        </div>
+      </div>
     </div>
   </div>
 </template>
@@ -186,6 +218,34 @@ const list = computed(() =>
 )
 
 const title = ref('')
+
+const editIndex = ref<number | null>(null)
+const editTitle = ref('')
+const editCategoryId = ref('')
+
+const openEdit = (i: number) => {
+  const t = list.value[i]
+  editIndex.value = i
+  editTitle.value = t.title
+  editCategoryId.value = t.categoryId || ''
+}
+
+const closeEdit = () => {
+  editIndex.value = null
+  editTitle.value = ''
+  editCategoryId.value = ''
+}
+
+const saveEdit = async () => {
+  if (editIndex.value === null || !user.value) return
+  const t = list.value[editIndex.value]
+  if (t?.id)
+    await updateDoc(doc(db, 'users', user.value.uid, 'todos', t.id), {
+      title: editTitle.value.trim(),
+      categoryId: editCategoryId.value || null,
+    })
+  closeEdit()
+}
 
 const add = async () => {
   const s = title.value.trim()


### PR DESCRIPTION
## Summary
- add edit button for each task with modal to change title and category
- implement logic to save updates to Firestore

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689b9c988cd8832eadb6e8afd27da5bc