### PR TITLE
feat: add category image upload

### DIFF
--- a/app/components/TodoList.vue
+++ b/app/components/TodoList.vue
@@ -137,6 +137,7 @@ interface Category {
   title: string
   icon: string
   background: string
+  image?: string
 }
 
 const day = useState('day', () => new Date().toISOString().slice(0, 10))

--- a/app/components/TodoList.vue
+++ b/app/components/TodoList.vue
@@ -1,7 +1,11 @@
 <template>
   <div class="max-w-3xl text-black">
     <h2 class="text-2xl font-bold mb-4 flex items-center gap-1"
-      :style="{ color: activeCategory?.background? textColor(activeCategory?.background) : '' }">
+      :style="{
+        color: activeCategory?.image
+          ? '#fff'
+          : (activeCategory?.background ? textColor(activeCategory.background) : undefined)
+      }">
       <span
         class="material-symbols-outlined text-4xl"
         v-if="activeCategory?.icon"

--- a/cors.json
+++ b/cors.json
@@ -1,0 +1,8 @@
+[
+  {
+    "origin": ["http://localhost:4000"],
+    "method": ["GET","POST","PUT","OPTIONS"],
+    "responseHeader": ["Content-Type","Authorization","x-goog-meta-*"],
+    "maxAgeSeconds": 3600
+  }
+]


### PR DESCRIPTION
## Summary
- allow selecting images when creating or editing categories
- upload images to Firebase Storage and store the storage path on the category
- reject uploads larger than 1MB and update related category types

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689c30d3e848832e97e178ce4225a824