### PR TITLE
feat: improve mobile layout

### DIFF
--- a/app/app.vue
+++ b/app/app.vue
@@ -12,10 +12,10 @@
     :style="{
       color: activeCategory?.background ? textColor(activeCategory.background) : ''
     }">
-    <div class="flex min-h-screen">
-      <div class="w-72 bg-white/25 backdrop-blur-2xl backdrop-saturate-150 
+    <div class="flex flex-col md:flex-row min-h-screen">
+      <div class="hidden md:block w-72 bg-white/25 backdrop-blur-2xl backdrop-saturate-150
             border border-white/40 shadow-lg p-5 fixed h-full"></div>
-      <aside class="w-72 flex flex-col justify-between p-5 relative">
+      <aside class="w-full md:w-72 flex flex-col justify-between p-5 relative">
         <div>
           <h1 class="flex items-center gap-2 text-lg font-bold">
             <span class="material-symbols-outlined">checklist</span> Todo
@@ -41,7 +41,7 @@
         </div>
         <AuthBlock />
       </aside>
-      <main class="flex-1 p-6">
+      <main class="flex-1 p-4 md:p-6">
         <NuxtPage />
       </main>
     </div>

--- a/app/app.vue
+++ b/app/app.vue
@@ -12,10 +12,18 @@
     :style="{
       color: activeCategory?.background ? textColor(activeCategory.background) : ''
     }">
+    <button
+      class="md:hidden absolute top-4 left-4 z-10 p-2 bg-white rounded shadow"
+      @click="sidebarOpen = !sidebarOpen"
+    >
+      <span class="material-symbols-outlined">{{ sidebarOpen ? 'close' : 'menu' }}</span>
+    </button>
     <div class="flex flex-col md:flex-row min-h-screen">
       <div class="hidden md:block w-72 bg-white/25 backdrop-blur-2xl backdrop-saturate-150
             border border-white/40 shadow-lg p-5 fixed h-full"></div>
-      <aside class="w-full md:w-72 flex flex-col justify-between p-5 relative">
+      <aside
+        :class="[sidebarOpen ? 'block' : 'hidden', 'md:block w-full md:w-72 flex flex-col justify-between p-5 relative']"
+      >
         <div>
           <h1 class="flex items-center gap-2 text-lg font-bold">
             <span class="material-symbols-outlined">checklist</span> Todo
@@ -50,7 +58,7 @@
 
 <script setup lang="ts">
 import { useRouter, useRoute } from 'vue-router'
-import { ref as vueRef, watch, computed } from 'vue'
+import { watch, computed } from 'vue'
 import { getStorage, ref as sref, getDownloadURL } from "firebase/storage"
 import DatePicker from 'vue-datepicker-next'
 import 'vue-datepicker-next/index.css'
@@ -84,6 +92,7 @@ const activeCategory = computed(() =>
 )
 
 const storage = getStorage()
+const sidebarOpen = ref(true)
 const imageUrl = ref<string>('')
 const urlCache = new Map<string, string>()
 

--- a/app/app.vue
+++ b/app/app.vue
@@ -13,7 +13,7 @@
       color: activeCategory?.background ? textColor(activeCategory.background) : ''
     }">
     <button
-      class="md:hidden absolute top-4 left-4 z-10 p-2 bg-white rounded shadow"
+      class="md:hidden absolute top-4 left-4 z-20 p-2 bg-white rounded shadow"
       @click="sidebarOpen = !sidebarOpen"
     >
       <span class="material-symbols-outlined">{{ sidebarOpen ? 'close' : 'menu' }}</span>
@@ -22,7 +22,11 @@
       <div class="hidden md:block w-72 bg-white/25 backdrop-blur-2xl backdrop-saturate-150
             border border-white/40 shadow-lg p-5 fixed h-full"></div>
       <aside
-        :class="[sidebarOpen ? 'block' : 'hidden', 'md:block w-full md:w-72 flex flex-col justify-between p-5 relative']"
+        :class="[
+          'fixed md:static top-0 left-0 h-full w-72 bg-white/25 backdrop-blur-2xl backdrop-saturate-150 border border-white/40 shadow-lg flex flex-col justify-between p-5 transition-transform duration-300 z-10',
+          sidebarOpen ? 'translate-x-0' : '-translate-x-full',
+          'md:translate-x-0'
+        ]"
       >
         <div>
           <h1 class="flex items-center gap-2 text-lg font-bold">
@@ -92,7 +96,7 @@ const activeCategory = computed(() =>
 )
 
 const storage = getStorage()
-const sidebarOpen = ref(true)
+const sidebarOpen = ref(false)
 const imageUrl = ref<string>('')
 const urlCache = new Map<string, string>()
 

--- a/app/components/TodoList.vue
+++ b/app/components/TodoList.vue
@@ -15,20 +15,20 @@
       {{ activeCategory?.title || 'ToDo' }} :: {{ day }}
     </h2>
     <div class="space-y-2">
-      <div class="flex gap-2">
+      <div class="flex flex-col md:flex-row gap-2">
         <input
           v-model="title"
           @keyup.enter="add"
           placeholder="New task…"
-          class="border rounded px-3 py-2 flex-1"
+          class="border rounded px-3 py-2 flex-1 w-full"
         />
-        <select v-model="categoryId" class="border rounded px-2">
+        <select v-model="categoryId" class="border rounded px-2 w-full md:w-auto">
           <option value="">No category</option>
           <option v-for="c in categories" :key="c.id" :value="c.id">
             {{ c.title }}
           </option>
         </select>
-        <button @click="add" class="bg-primary text-white px-4 rounded">Add</button>
+        <button @click="add" class="bg-primary text-white px-4 rounded w-full md:w-auto">Add</button>
       </div>
       <draggable
         :modelValue="list"

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -14,6 +14,9 @@ export default defineNuxtConfig({
   css: ['~/assets/css/tailwind.css', 'animate.css/animate.min.css'],
   app: {
     head: {
+      meta: [
+        { name: 'viewport', content: 'width=device-width, initial-scale=1' }
+      ],
       link: [
         { rel: 'preconnect', href: 'https://fonts.googleapis.com' },
         { rel: 'stylesheet', href: 'https://fonts.googleapis.com/css2?family=Inter:wght@400;600;800&display=swap' },


### PR DESCRIPTION
## Summary
- add mobile-friendly viewport meta tag
- stack sidebar and content on small screens
- make todo input row responsive

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_689d5ad1b0b8832e8fffd4ef8cc7ac80