### PR TITLE
feat: share todo lists by link

### DIFF
--- a/app/app.vue
+++ b/app/app.vue
@@ -13,15 +13,19 @@
       color: activeCategory?.background ? textColor(activeCategory.background) : ''
     }">
     <button
+      v-if="!isShareRoute"
       class="md:hidden absolute top-4 left-4 z-20 p-2 bg-white rounded shadow"
       @click="sidebarOpen = !sidebarOpen"
     >
       <span class="material-symbols-outlined">{{ sidebarOpen ? 'close' : 'menu' }}</span>
     </button>
     <div class="flex flex-col md:flex-row min-h-screen">
-      <div class="hidden md:block w-72 bg-white/25 backdrop-blur-2xl backdrop-saturate-150
+      <div
+        v-if="!isShareRoute"
+        class="hidden md:block w-72 bg-white/25 backdrop-blur-2xl backdrop-saturate-150
             border border-white/40 shadow-lg p-5 fixed h-full"></div>
       <aside
+        v-if="!isShareRoute"
         :class="[
           'fixed md:static top-0 left-0 h-full w-72 bg-white/25 backdrop-blur-2xl backdrop-saturate-150 border border-white/40 shadow-lg flex flex-col justify-between p-5 transition-transform duration-300 z-10',
           sidebarOpen ? 'translate-x-0' : '-translate-x-full',
@@ -99,6 +103,7 @@ const storage = getStorage()
 const sidebarOpen = ref(false)
 const imageUrl = ref<string>('')
 const urlCache = new Map<string, string>()
+const isShareRoute = computed(() => route.path.startsWith('/share'))
 
 watch(() => activeCategory.value?.image, async (path) => {
   if (!path) { imageUrl.value = ''; return }

--- a/app/components/TodoList.vue
+++ b/app/components/TodoList.vue
@@ -13,6 +13,12 @@
       >
       <span v-else class="material-symbols-outlined">checklist</span>
       {{ activeCategory?.title || 'ToDo' }} :: {{ day }}
+      <button
+        v-if="user"
+        @click="shareList"
+        class="ml-auto material-symbols-outlined text-base"
+        aria-label="Share list"
+      >share</button>
     </h2>
     <div class="space-y-2">
       <div class="flex flex-col md:flex-row gap-2">
@@ -308,6 +314,22 @@ const onReorder = async (newList: Todo[]) => {
     })
   })
   await batch.commit()
+}
+
+const shareList = async () => {
+  if (!user.value) return
+  const docRef = await addDoc(collection(db, 'share'), {
+    uid: user.value.uid,
+    date: day.value,
+    categoryId: activeCategoryId.value || '',
+  })
+  const url = `${window.location.origin}/share/${docRef.id}`
+  try {
+    await navigator.clipboard.writeText(url)
+    alert('Link copied to clipboard')
+  } catch (e) {
+    window.prompt('Share this link', url)
+  }
 }
 
 function textColor(bg: string) {

--- a/app/error.vue
+++ b/app/error.vue
@@ -1,0 +1,13 @@
+<template>
+  <div class="min-h-screen flex flex-col items-center justify-center bg-gray-50 text-center text-gray-700">
+    <h1 class="text-8xl font-extrabold text-gray-300">404</h1>
+    <p class="mt-4 text-2xl" v-if="error.statusCode === 404">Shared list not found</p>
+    <p class="mt-4 text-2xl" v-else>{{ error.message }}</p>
+    <button class="mt-6 px-4 py-2 bg-blue-600 text-white rounded" @click="handleError">Go back home</button>
+  </div>
+</template>
+
+<script setup lang="ts">
+const error = useError()
+const handleError = () => clearError({ redirect: '/' })
+</script>

--- a/app/pages/share/[uid].vue
+++ b/app/pages/share/[uid].vue
@@ -21,6 +21,7 @@ import { useRoute } from 'vue-router'
 import { useFirebaseApp } from 'vuefire'
 import { getFirestore, doc, getDoc, collection, query, where, orderBy, getDocs } from 'firebase/firestore'
 import { ref, computed, onMounted } from 'vue'
+import { showError } from '#app'
 
 interface Share { uid: string; date: string; categoryId: string }
 interface Todo { id?: string; title: string; done: boolean; categoryId: string | null; order: number; createdAt?: any }
@@ -45,7 +46,10 @@ const headerStyle = computed(() => ({
 onMounted(async () => {
   const id = route.params.uid as string
   const snap = await getDoc(doc(db, 'share', id))
-  if (!snap.exists()) return
+  if (!snap.exists()) {
+    showError({ statusCode: 404, statusMessage: 'Shared list not found' })
+    return
+  }
   share.value = snap.data() as Share
   const { uid, date, categoryId } = share.value
   let q = query(

--- a/app/pages/share/[uid].vue
+++ b/app/pages/share/[uid].vue
@@ -1,0 +1,89 @@
+<template>
+  <div class="max-w-3xl text-black">
+    <h2 class="text-2xl font-bold mb-4 flex items-center gap-1" :style="headerStyle">
+      <span class="material-symbols-outlined text-4xl" v-if="category?.icon">{{ category.icon }}</span>
+      <span v-else class="material-symbols-outlined">checklist</span>
+      {{ category?.title || 'ToDo' }} :: {{ share?.date }}
+    </h2>
+    <ul class="space-y-2">
+      <li v-for="t in tasks" :key="t.id">
+        <div class="bg-white border rounded p-2 flex items-center gap-2">
+          <input class="w-5 h-5 accent-green-600" type="checkbox" :checked="t.done" disabled />
+          <span :class="{ 'line-through text-gray-400': t.done }">{{ t.title }}</span>
+        </div>
+      </li>
+    </ul>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { useRoute } from 'vue-router'
+import { useFirebaseApp } from 'vuefire'
+import { getFirestore, doc, getDoc, collection, query, where, orderBy, getDocs } from 'firebase/firestore'
+import { ref, computed, onMounted } from 'vue'
+
+interface Share { uid: string; date: string; categoryId: string }
+interface Todo { id?: string; title: string; done: boolean; categoryId: string | null; order: number; createdAt?: any }
+interface Category { id?: string; title: string; icon: string; background: string; image?: string }
+
+const route = useRoute()
+const app = useFirebaseApp()
+const db = getFirestore(app)
+
+const share = ref<Share | null>(null)
+const tasks = useState<Todo[]>('tasks', () => [])
+const category = ref<Category | null>(null)
+const categories = useState<Category[]>('categories', () => [])
+const activeCategoryId = useState<string>('activeCategoryId', () => '')
+
+const headerStyle = computed(() => ({
+  color: category.value?.image
+    ? '#fff'
+    : (category.value?.background ? textColor(category.value.background) : undefined)
+}))
+
+onMounted(async () => {
+  const id = route.params.uid as string
+  const snap = await getDoc(doc(db, 'share', id))
+  if (!snap.exists()) return
+  share.value = snap.data() as Share
+  const { uid, date, categoryId } = share.value
+  let q = query(
+    collection(db, 'users', uid, 'todos'),
+    where('date', '==', date),
+    orderBy('order'),
+    orderBy('createdAt', 'desc')
+  )
+  if (categoryId) q = query(q, where('categoryId', '==', categoryId))
+  const taskSnap = await getDocs(q)
+  tasks.value = taskSnap.docs.map(d => ({ id: d.id, ...(d.data() as Omit<Todo,'id'>) }))
+  if (categoryId) {
+    const catSnap = await getDoc(doc(db, 'users', uid, 'categories', categoryId))
+    if (catSnap.exists()) {
+      category.value = { id: catSnap.id, ...(catSnap.data() as Omit<Category,'id'>) }
+      categories.value = [category.value]
+      activeCategoryId.value = categoryId
+    }
+  } else {
+    categories.value = []
+    activeCategoryId.value = ''
+  }
+})
+
+function textColor(bg: string) {
+  const { r, g, b } = toRGB(bg);
+  const L = (0.2126 * r + 0.7152 * g + 0.0722 * b) / 255;
+  return L > 0.6 ? '#111827' : '#ffffff';
+}
+
+function toRGB(color: string) {
+  if (!color) return { r: 0, g: 0, b: 0 };
+  if (color.startsWith('#')) {
+    const hex = color.slice(1).replace(/^(.)(.)(.)$/, '$1$1$2$2$3$3');
+    const num = parseInt(hex, 16);
+    return { r: (num >> 16) & 255, g: (num >> 8) & 255, b: num & 255 };
+  }
+  const m = color.match(/\d+/g);
+  return m ? { r: +m[0], g: +Number(m[1]), b: +Number(m[2]) } : { r: 0, g: 0, b: 0 };
+}
+</script>


### PR DESCRIPTION
## Summary
- add share button that generates public links
- hide sidebar on shared pages
- implement `/share/:uid` page to show tasks with category styling

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_689d9aea1930832e8b08db884d223a12