### PR TITLE
refactor: centralize color helpers

### DIFF
--- a/app/app.vue
+++ b/app/app.vue
@@ -72,6 +72,7 @@ import DatePicker from 'vue-datepicker-next'
 import 'vue-datepicker-next/index.css'
 import { format } from 'date-fns'
 import CategoryList from './components/CategoryList.vue'
+import { textColor } from './utils/color'
 
 interface Todo {
   date: string
@@ -153,24 +154,6 @@ const getDayClass = (value: Date, _innerValue: Date[], classes: string) => {
 
 const onDateSelect = (newDate: string | Date) => {
   router.push(`/date/${newDate}`);
-}
-
-function textColor(bg: string) {
-  const { r, g, b } = toRGB(bg);
-  const L = (0.2126 * r + 0.7152 * g + 0.0722 * b) / 255;
-  return L > 0.6 ? '#111827' : '#ffffff';
-}
-
-function toRGB(color: string) {
-  if (!color) return { r: 0, g: 0, b: 0 };
-  if (color.startsWith('#')) {
-    const hex = color.slice(1).replace(/^(.)(.)(.)$/, '$1$1$2$2$3$3');
-    const num = parseInt(hex, 16);
-    return { r: (num >> 16) & 255, g: (num >> 8) & 255, b: num & 255 };
-  }
-
-  const m = color.match(/\d+/g);
-  return m ? { r: +m[0], g: +Number(m[1]), b: +Number(m[2]) } : { r: 0, g: 0, b: 0 };
 }
 </script>
 

--- a/app/components/CategoryList.vue
+++ b/app/components/CategoryList.vue
@@ -128,6 +128,7 @@ import {
   deleteField
 } from 'firebase/firestore'
 import { getStorage, ref as storageRef, uploadBytes, deleteObject } from 'firebase/storage'
+import { textColor } from '../utils/color'
 
 interface Category {
   id?: string
@@ -330,23 +331,5 @@ const deleteCategory = async () => {
 const toggleFilter = (id?: string) => {
   if (!id) return
   activeCategoryId.value = activeCategoryId.value === id ? '' : id
-}
-
-function textColor(bg: string) {
-  const { r, g, b } = toRGB(bg);
-  const L = (0.2126 * r + 0.7152 * g + 0.0722 * b) / 255;
-  return L > 0.6 ? '#111827' : '#ffffff';
-}
-
-function toRGB(color: string) {
-  if (!color) return { r: 0, g: 0, b: 0 };
-  if (color.startsWith('#')) {
-    const hex = color.slice(1).replace(/^(.)(.)(.)$/, '$1$1$2$2$3$3');
-    const num = parseInt(hex, 16);
-    return { r: (num >> 16) & 255, g: (num >> 8) & 255, b: num & 255 };
-  }
-
-  const m = color.match(/\d+/g);
-  return m ? { r: +m[0], g: +Number(m[1]), b: +Number(m[2]) } : { r: 0, g: 0, b: 0 };
 }
 </script>

--- a/app/components/TodoList.vue
+++ b/app/components/TodoList.vue
@@ -153,6 +153,7 @@ import {
 } from 'firebase/firestore'
 import { format, startOfMonth, endOfMonth } from 'date-fns'
 import draggable from 'vuedraggable'
+import { textColor } from '../utils/color'
 
 interface Todo {
   id?: string
@@ -375,23 +376,5 @@ const unshareList = async () => {
   if (!shareId.value) return
   await deleteDoc(doc(db, 'share', shareId.value))
   shareId.value = null
-}
-
-function textColor(bg: string) {
-  const { r, g, b } = toRGB(bg);
-  const L = (0.2126 * r + 0.7152 * g + 0.0722 * b) / 255;
-  return L > 0.6 ? '#111827' : '#ffffff';
-}
-
-function toRGB(color: string) {
-  if (!color) return { r: 0, g: 0, b: 0 };
-  if (color.startsWith('#')) {
-    const hex = color.slice(1).replace(/^(.)(.)(.)$/, '$1$1$2$2$3$3');
-    const num = parseInt(hex, 16);
-    return { r: (num >> 16) & 255, g: (num >> 8) & 255, b: num & 255 };
-  }
-
-  const m = color.match(/\d+/g);
-  return m ? { r: +m[0], g: +Number(m[1]), b: +Number(m[2]) } : { r: 0, g: 0, b: 0 };
 }
 </script>

--- a/app/pages/share/[uid].vue
+++ b/app/pages/share/[uid].vue
@@ -22,6 +22,7 @@ import { useFirebaseApp } from 'vuefire'
 import { getFirestore, doc, getDoc, collection, query, where, orderBy, getDocs } from 'firebase/firestore'
 import { ref, computed, onMounted } from 'vue'
 import { showError } from '#app'
+import { textColor } from '../../utils/color'
 
 interface Share { uid: string; date: string; categoryId: string }
 interface Todo { id?: string; title: string; done: boolean; categoryId: string | null; order: number; createdAt?: any }
@@ -73,21 +74,4 @@ onMounted(async () => {
     activeCategoryId.value = ''
   }
 })
-
-function textColor(bg: string) {
-  const { r, g, b } = toRGB(bg);
-  const L = (0.2126 * r + 0.7152 * g + 0.0722 * b) / 255;
-  return L > 0.6 ? '#111827' : '#ffffff';
-}
-
-function toRGB(color: string) {
-  if (!color) return { r: 0, g: 0, b: 0 };
-  if (color.startsWith('#')) {
-    const hex = color.slice(1).replace(/^(.)(.)(.)$/, '$1$1$2$2$3$3');
-    const num = parseInt(hex, 16);
-    return { r: (num >> 16) & 255, g: (num >> 8) & 255, b: num & 255 };
-  }
-  const m = color.match(/\d+/g);
-  return m ? { r: +m[0], g: +Number(m[1]), b: +Number(m[2]) } : { r: 0, g: 0, b: 0 };
-}
 </script>

--- a/app/utils/color.ts
+++ b/app/utils/color.ts
@@ -1,0 +1,17 @@
+export function textColor(bg: string) {
+  const { r, g, b } = toRGB(bg);
+  const L = (0.2126 * r + 0.7152 * g + 0.0722 * b) / 255;
+  return L > 0.6 ? '#111827' : '#ffffff';
+}
+
+export function toRGB(color: string) {
+  if (!color) return { r: 0, g: 0, b: 0 };
+  if (color.startsWith('#')) {
+    const hex = color.slice(1).replace(/^(.)(.)(.)$/, '$1$1$2$2$3$3');
+    const num = parseInt(hex, 16);
+    return { r: (num >> 16) & 255, g: (num >> 8) & 255, b: num & 255 };
+  }
+
+  const m = color.match(/\d+/g);
+  return m ? { r: +m[0], g: +Number(m[1]), b: +Number(m[2]) } : { r: 0, g: 0, b: 0 };
+}


### PR DESCRIPTION
## Summary
- extract textColor/toRGB helpers into utils/color.ts
- reuse textColor across app, todo list, category list, and share page

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689db6341c94832e82929b6180801b14