### PR TITLE
refactor: move category modal out of sidebar

### DIFF
--- a/app/app.vue
+++ b/app/app.vue
@@ -62,8 +62,10 @@
         <NuxtPage />
       </main>
     </div>
-  </div>
-</template>
+      <CategoryModal />
+      <TaskModal />
+    </div>
+  </template>
 
 <script setup lang="ts">
 import { useRouter, useRoute } from 'vue-router'
@@ -73,7 +75,9 @@ import DatePicker from 'vue-datepicker-next'
 import 'vue-datepicker-next/index.css'
 import { format } from 'date-fns'
 import CategoryList from './components/CategoryList.vue'
-import { textColor } from './utils/color'
+  import CategoryModal from './components/CategoryModal.vue'
+  import TaskModal from './components/TaskModal.vue'
+  import { textColor } from './utils/color'
 
 interface Todo {
   date: string

--- a/app/components/CategoryModal.vue
+++ b/app/components/CategoryModal.vue
@@ -189,6 +189,7 @@ const saveCategory = async () => {
   if (!user.value) return
   const title = newCategory.title.trim()
   if (!title) return
+  showModal.value = false
   if (editingId.value) {
     let imagePath = newCategory.image || ''
     if (imageFile.value) {
@@ -226,6 +227,5 @@ const saveCategory = async () => {
   imageFile.value = null
   editingId.value = null
   categoryToEdit.value = null
-  showModal.value = false
 }
 </script>

--- a/app/components/CategoryModal.vue
+++ b/app/components/CategoryModal.vue
@@ -1,0 +1,231 @@
+<template>
+  <div
+    v-if="showModal"
+    class="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-[3000]"
+  >
+    <div class="bg-white p-4 rounded shadow w-80 text-black">
+      <h4 class="text-lg font-semibold mb-2">
+        {{ editingId ? 'Edit category' : 'New category' }}
+      </h4>
+      <div class="space-y-2">
+        <input
+          v-model="newCategory.title"
+          placeholder="Title"
+          class="border rounded w-full px-2 py-1"
+        />
+        <div>
+          <span class="block text-sm mb-1">Icon</span>
+          <div class="grid grid-cols-5 gap-2">
+            <button
+              v-for="icon in iconOptions"
+              :key="icon"
+              type="button"
+              @click="newCategory.icon = icon"
+              :class="[
+                'p-2 border rounded flex items-center justify-center',
+                newCategory.icon === icon ? 'bg-primary text-white' : 'bg-gray-100'
+              ]"
+            >
+              <span class="material-symbols-outlined">{{ icon }}</span>
+            </button>
+          </div>
+        </div>
+        <div>
+          <span class="block text-sm mb-1">Background</span>
+          <div class="grid grid-cols-6 gap-2">
+            <button
+              v-for="color in colorOptions"
+              :key="color"
+              type="button"
+              @click="newCategory.background = color"
+              :style="{ background: color }"
+              :class="[
+                'w-8 h-8 rounded',
+                newCategory.background === color ? 'ring-2 ring-offset-2 ring-primary' : ''
+              ]"
+            ></button>
+          </div>
+        </div>
+        <div>
+          <span class="block text-sm mb-1">Image</span>
+          <div v-if="newCategory.image" class="flex items-center gap-2">
+            <button type="button" @click="removeImage" class="px-2 py-1 bg-red-500 text-white rounded">
+              Remove image
+            </button>
+          </div>
+          <input v-else type="file" accept="image/*" @change="onFileChange" />
+        </div>
+      </div>
+      <div class="mt-4 flex justify-end gap-2">
+        <button @click="closeModal" class="px-3 py-1 bg-gray-200 rounded">
+          Cancel
+        </button>
+        <button @click="saveCategory" class="px-3 py-1 bg-primary text-white rounded">
+          Save
+        </button>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, reactive, watch } from 'vue'
+import { useFirebaseApp } from 'vuefire'
+import {
+  getFirestore,
+  collection,
+  addDoc,
+  updateDoc,
+  doc,
+  deleteField
+} from 'firebase/firestore'
+import { getStorage, ref as storageRef, uploadBytes, deleteObject } from 'firebase/storage'
+
+interface Category {
+  id?: string
+  title: string
+  icon: string
+  background: string
+  image?: string
+}
+
+const user = useState<{ uid: string } | null>('user', () => null)
+const categoryToEdit = useState<Category | null>('categoryToEdit', () => null)
+const showModal = useState<boolean>('showCategoryModal', () => false)
+
+const iconOptions = [
+  'home',
+  'stadia_controller',
+  'work',
+  'key',
+  'person',
+  'person_book',
+  'shopping_basket',
+  'shopping_cart',
+  'movie',
+  'exercise'
+]
+
+const colorOptions = [
+  '#F9FAFB',
+  '#87CEFA',
+  '#90EE90',
+  '#800000',
+  '#FFA500',
+  '#808080',
+  '#F9DF1D',
+  '#D0D0D0',
+  '#3F51B5',
+  '#607D8B',
+  '#009688',
+  '#A52A2A'
+]
+
+const newCategory = reactive({
+  title: '',
+  icon: iconOptions[0],
+  background: colorOptions[0],
+  image: ''
+})
+
+const editingId = ref<string | null>(null)
+const imageFile = ref<File | null>(null)
+
+const app = useFirebaseApp()
+const db = getFirestore(app)
+const storage = getStorage(app)
+
+watch(showModal, (val) => {
+  if (val) {
+    if (categoryToEdit.value) {
+      editingId.value = categoryToEdit.value.id || null
+      newCategory.title = categoryToEdit.value.title
+      newCategory.icon = categoryToEdit.value.icon
+      newCategory.background = categoryToEdit.value.background
+      newCategory.image = categoryToEdit.value.image || ''
+    } else {
+      editingId.value = null
+      newCategory.title = ''
+      newCategory.icon = iconOptions[0]
+      newCategory.background = colorOptions[0]
+      newCategory.image = ''
+    }
+    imageFile.value = null
+  }
+})
+
+const onFileChange = (e: Event) => {
+  const file = (e.target as HTMLInputElement).files?.[0]
+  if (file) {
+    if (file.size > 1024 * 1024) {
+      alert('Image must be less than 1MB')
+      ;(e.target as HTMLInputElement).value = ''
+      return
+    }
+    imageFile.value = file
+  }
+}
+
+const removeImage = async () => {
+  if (!user.value || !editingId.value || !newCategory.image) return
+  try {
+    await deleteObject(storageRef(storage, newCategory.image))
+  } catch (e) {
+    console.error('Error deleting image from storage', e)
+  }
+  await updateDoc(doc(db, 'users', user.value.uid, 'categories', editingId.value), {
+    image: deleteField()
+  })
+  newCategory.image = ''
+}
+
+const closeModal = () => {
+  showModal.value = false
+  categoryToEdit.value = null
+  imageFile.value = null
+}
+
+const saveCategory = async () => {
+  if (!user.value) return
+  const title = newCategory.title.trim()
+  if (!title) return
+  if (editingId.value) {
+    let imagePath = newCategory.image || ''
+    if (imageFile.value) {
+      const path = `users/${user.value.uid}/categories/${editingId.value}/${imageFile.value.name}`
+      const sRef = storageRef(storage, path)
+      await uploadBytes(sRef, imageFile.value)
+      imagePath = path
+    }
+    await updateDoc(
+      doc(db, 'users', user.value.uid, 'categories', editingId.value),
+      {
+        title,
+        icon: newCategory.icon?.trim(),
+        background: newCategory.background,
+        image: imagePath
+      }
+    )
+  } else {
+    const docRef = await addDoc(collection(db, 'users', user.value.uid, 'categories'), {
+      title,
+      icon: newCategory.icon?.trim(),
+      background: newCategory.background
+    })
+    if (imageFile.value) {
+      const path = `users/${user.value.uid}/categories/${docRef.id}/${imageFile.value.name}`
+      const sRef = storageRef(storage, path)
+      await uploadBytes(sRef, imageFile.value)
+      await updateDoc(docRef, { image: path })
+    }
+  }
+  newCategory.title = ''
+  newCategory.icon = iconOptions[0]
+  newCategory.background = colorOptions[0]
+  newCategory.image = ''
+  imageFile.value = null
+  editingId.value = null
+  categoryToEdit.value = null
+  showModal.value = false
+}
+</script>

--- a/app/components/TaskModal.vue
+++ b/app/components/TaskModal.vue
@@ -1,0 +1,102 @@
+<template>
+  <div
+    v-if="showModal"
+    class="fixed inset-0 bg-black/50 flex items-center justify-center z-[3000]"
+  >
+    <div class="bg-white p-6 rounded shadow max-w-sm w-full">
+      <h3 class="text-lg font-bold mb-4">Edit task</h3>
+      <input
+        v-model="editTitle"
+        class="border rounded px-3 py-2 w-full mb-2"
+      />
+      <select
+        v-model="editCategoryId"
+        class="border rounded px-3 py-2 w-full mb-2"
+      >
+        <option value="">No category</option>
+        <option v-for="c in categories" :key="c.id" :value="c.id">
+          {{ c.title }}
+        </option>
+      </select>
+      <input
+        type="date"
+        v-model="editDate"
+        class="border rounded px-3 py-2 w-full mb-4"
+      />
+      <div class="flex justify-end gap-2">
+        <button @click="closeModal" class="px-3 py-1 bg-gray-200 rounded">
+          Cancel
+        </button>
+        <button @click="saveTask" class="px-3 py-1 bg-primary text-white rounded">
+          Save
+        </button>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, watch } from 'vue'
+import { useFirebaseApp } from 'vuefire'
+import { getFirestore, doc, updateDoc } from 'firebase/firestore'
+
+interface Todo {
+  id?: string
+  title: string
+  order: number
+  date: string
+  done: boolean
+  categoryId: string | null
+}
+
+interface Category {
+  id: string
+  title: string
+  icon?: string
+  background?: string
+  image?: string
+}
+
+const user = useState<{ uid: string } | null>('user', () => null)
+const categories = useState<Category[]>('categories', () => [])
+const taskToEdit = useState<Todo | null>('taskToEdit', () => null)
+const showModal = useState<boolean>('showTaskModal', () => false)
+
+const editTitle = ref('')
+const editCategoryId = ref('')
+const editDate = ref('')
+
+const app = useFirebaseApp()
+const db = getFirestore(app)
+
+watch(showModal, (val) => {
+  if (val && taskToEdit.value) {
+    editTitle.value = taskToEdit.value.title
+    editCategoryId.value = taskToEdit.value.categoryId || ''
+    editDate.value = taskToEdit.value.date
+  } else {
+    editTitle.value = ''
+    editCategoryId.value = ''
+    editDate.value = ''
+    taskToEdit.value = null
+  }
+})
+
+const closeModal = () => {
+  showModal.value = false
+}
+
+const saveTask = async () => {
+  if (!user.value || !taskToEdit.value?.id) return
+  const title = editTitle.value.trim()
+  const categoryId = editCategoryId.value || null
+  const date = editDate.value
+  showModal.value = false
+  await updateDoc(doc(db, 'users', user.value.uid, 'todos', taskToEdit.value.id), {
+    title,
+    categoryId,
+    date,
+  })
+  taskToEdit.value = null
+}
+</script>

--- a/app/components/TodoList.vue
+++ b/app/components/TodoList.vue
@@ -98,40 +98,6 @@
         </template>
       </draggable>
     </div>
-    <div
-      v-if="editIndex !== null"
-      class="fixed inset-0 bg-black/50 flex items-center justify-center z-[3000]"
-    >
-      <div class="bg-white p-6 rounded shadow max-w-sm w-full">
-        <h3 class="text-lg font-bold mb-4">Edit task</h3>
-        <input
-          v-model="editTitle"
-          class="border rounded px-3 py-2 w-full mb-2"
-        />
-        <select
-          v-model="editCategoryId"
-          class="border rounded px-3 py-2 w-full mb-2"
-        >
-          <option value="">No category</option>
-          <option v-for="c in categories" :key="c.id" :value="c.id">
-            {{ c.title }}
-          </option>
-        </select>
-        <input
-          type="date"
-          v-model="editDate"
-          class="border rounded px-3 py-2 w-full mb-4"
-        />
-        <div class="flex justify-end gap-2">
-          <button @click="closeEdit" class="px-4 py-2 rounded border">
-            Cancel
-          </button>
-          <button @click="saveEdit" class="bg-primary text-white px-4 py-2 rounded">
-            Save
-          </button>
-        </div>
-      </div>
-    </div>
   </div>
 </template>
 
@@ -286,40 +252,14 @@ const list = computed(() =>
 
 const title = ref('')
 
-const editIndex = ref<number | null>(null)
-const editTitle = ref('')
-const editCategoryId = ref('')
-const editDate = ref('')
+const taskToEdit = useState<Todo | null>('taskToEdit', () => null)
+const showTaskModal = useState<boolean>('showTaskModal', () => false)
 
 const openEdit = (i: number) => {
   const t = list.value[i]
   if (!t) return
-  editIndex.value = i
-  editTitle.value = t.title
-  editCategoryId.value = t.categoryId || ''
-  editDate.value = t.date
-}
-
-const closeEdit = () => {
-  editIndex.value = null
-  editTitle.value = ''
-  editCategoryId.value = ''
-  editDate.value = ''
-}
-
-const saveEdit = async () => {
-  if (editIndex.value === null || !user.value) return
-  const t = list.value[editIndex.value]
-  const title = editTitle.value.trim()
-  const categoryId = editCategoryId.value || null
-  const date = editDate.value
-  closeEdit()
-  if (t?.id)
-    await updateDoc(doc(db, 'users', user.value.uid, 'todos', t.id), {
-      title,
-      categoryId,
-      date,
-    })
+  taskToEdit.value = { ...t }
+  showTaskModal.value = true
 }
 
 const add = async () => {


### PR DESCRIPTION
## Summary
- move category modal to standalone component
- open modal via shared state instead of sidebar
- extract task edit modal to standalone component and open via shared state

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689e416bc3b4832e9bbe2d767874aa48