### PR TITLE
feat: extract category delete modal

### DIFF
--- a/app/app.vue
+++ b/app/app.vue
@@ -64,6 +64,7 @@
     </div>
       <CategoryModal />
       <TaskModal />
+      <DeleteCategoryModal />
     </div>
   </template>
 
@@ -77,6 +78,7 @@ import { format } from 'date-fns'
 import CategoryList from './components/CategoryList.vue'
   import CategoryModal from './components/CategoryModal.vue'
   import TaskModal from './components/TaskModal.vue'
+  import DeleteCategoryModal from './components/DeleteCategoryModal.vue'
   import { textColor } from './utils/color'
 
 interface Todo {

--- a/app/app.vue
+++ b/app/app.vue
@@ -62,9 +62,9 @@
         <NuxtPage />
       </main>
     </div>
+      <DeleteCategoryModal />
       <CategoryModal />
       <TaskModal />
-      <DeleteCategoryModal />
     </div>
   </template>
 
@@ -75,11 +75,11 @@ import { getStorage, ref as sref, getDownloadURL } from "firebase/storage"
 import DatePicker from 'vue-datepicker-next'
 import 'vue-datepicker-next/index.css'
 import { format } from 'date-fns'
+import DeleteCategoryModal from './components/DeleteCategoryModal.vue'
 import CategoryList from './components/CategoryList.vue'
-  import CategoryModal from './components/CategoryModal.vue'
-  import TaskModal from './components/TaskModal.vue'
-  import DeleteCategoryModal from './components/DeleteCategoryModal.vue'
-  import { textColor } from './utils/color'
+import CategoryModal from './components/CategoryModal.vue'
+import TaskModal from './components/TaskModal.vue'
+import { textColor } from './utils/color'
 
 interface Todo {
   date: string

--- a/app/components/CategoryList.vue
+++ b/app/components/CategoryList.vue
@@ -28,34 +28,16 @@
     >
       + Add category
     </button>
-    <div
-      v-if="showDeleteModal"
-      class="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-[3000]"
-    >
-      <div class="bg-white p-4 rounded shadow w-80">
-        <h4 class="text-lg font-semibold mb-2">Delete category?</h4>
-        <p class="mb-4">This will also delete all tasks in this category.</p>
-        <div class="flex justify-end gap-2">
-          <button @click="cancelDelete" class="px-3 py-1 bg-gray-200 rounded">Cancel</button>
-          <button @click="deleteCategory" class="px-3 py-1 bg-red-500 text-white rounded">Delete</button>
-        </div>
-      </div>
-    </div>
   </div>
 </template>
 
 <script setup lang="ts">
-import { watch, onUnmounted, ref } from 'vue'
+import { watch, onUnmounted } from 'vue'
 import { useFirebaseApp } from 'vuefire'
 import {
   getFirestore,
   collection,
-  onSnapshot,
-  doc,
-  deleteDoc,
-  getDocs,
-  query,
-  where
+  onSnapshot
 } from 'firebase/firestore'
 import { textColor } from '../utils/color'
 
@@ -100,8 +82,8 @@ onUnmounted(() => {
   if (off) off()
 })
 
-const showDeleteModal = ref(false)
-const categoryToDelete = ref<Category | null>(null)
+const categoryToDelete = useState<Category | null>('categoryToDelete', () => null)
+const showDeleteCategoryModal = useState<boolean>('showDeleteCategoryModal', () => false)
 
 const openModal = (c?: Category) => {
   if (!user.value) return
@@ -111,26 +93,7 @@ const openModal = (c?: Category) => {
 
 const confirmDelete = (c: Category) => {
   categoryToDelete.value = c
-  showDeleteModal.value = true
-}
-
-const cancelDelete = () => {
-  showDeleteModal.value = false
-  categoryToDelete.value = null
-}
-
-const deleteCategory = async () => {
-  if (!user.value || !categoryToDelete.value?.id) return
-  const id = categoryToDelete.value.id
-  await deleteDoc(doc(db, 'users', user.value.uid, 'categories', id))
-  const q = query(
-    collection(db, 'users', user.value.uid, 'todos'),
-    where('categoryId', '==', id)
-  )
-  const snap = await getDocs(q)
-  await Promise.all(snap.docs.map((d) => deleteDoc(d.ref)))
-  if (activeCategoryId.value === id) activeCategoryId.value = ''
-  cancelDelete()
+  showDeleteCategoryModal.value = true
 }
 
 const toggleFilter = (id?: string) => {

--- a/app/components/DeleteCategoryModal.vue
+++ b/app/components/DeleteCategoryModal.vue
@@ -1,0 +1,63 @@
+<template>
+  <div
+    v-if="showModal"
+    class="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-[3000]"
+  >
+    <div class="bg-white p-4 rounded shadow w-80">
+      <h4 class="text-lg font-semibold mb-2">Delete category?</h4>
+      <p class="mb-4">This will also delete all tasks in this category.</p>
+      <div class="flex justify-end gap-2">
+        <button @click="cancelDelete" class="px-3 py-1 bg-gray-200 rounded">Cancel</button>
+        <button @click="deleteCategory" class="px-3 py-1 bg-red-500 text-white rounded">Delete</button>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { useFirebaseApp } from 'vuefire'
+import {
+  getFirestore,
+  collection,
+  doc,
+  deleteDoc,
+  getDocs,
+  query,
+  where
+} from 'firebase/firestore'
+
+interface Category {
+  id?: string
+  title: string
+  icon: string
+  background: string
+  image?: string
+}
+
+const user = useState<{ uid: string } | null>('user', () => null)
+const activeCategoryId = useState<string>('activeCategoryId', () => '')
+const categoryToDelete = useState<Category | null>('categoryToDelete', () => null)
+const showModal = useState<boolean>('showDeleteCategoryModal', () => false)
+
+const app = useFirebaseApp()
+const db = getFirestore(app)
+
+const cancelDelete = () => {
+  showModal.value = false
+  categoryToDelete.value = null
+}
+
+const deleteCategory = async () => {
+  if (!user.value || !categoryToDelete.value?.id) return
+  const id = categoryToDelete.value.id
+  await deleteDoc(doc(db, 'users', user.value.uid, 'categories', id))
+  const q = query(
+    collection(db, 'users', user.value.uid, 'todos'),
+    where('categoryId', '==', id)
+  )
+  const snap = await getDocs(q)
+  await Promise.all(snap.docs.map((d) => deleteDoc(d.ref)))
+  if (activeCategoryId.value === id) activeCategoryId.value = ''
+  cancelDelete()
+}
+</script>

--- a/app/components/DeleteCategoryModal.vue
+++ b/app/components/DeleteCategoryModal.vue
@@ -50,6 +50,7 @@ const cancelDelete = () => {
 const deleteCategory = async () => {
   if (!user.value || !categoryToDelete.value?.id) return
   const id = categoryToDelete.value.id
+  showModal.value = false
   await deleteDoc(doc(db, 'users', user.value.uid, 'categories', id))
   const q = query(
     collection(db, 'users', user.value.uid, 'todos'),


### PR DESCRIPTION
## Summary
- move inline category delete dialog to its own DeleteCategoryModal component
- trigger global state to show delete modal from CategoryList
- mount DeleteCategoryModal next to other app modals

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a12c2d1da0832e8ffb0713c16e5b95