### PR TITLE
style: enhance login UI with glowing card and icons

### DIFF
--- a/app/pages/login.vue
+++ b/app/pages/login.vue
@@ -1,6 +1,17 @@
 <template>
-  <div class="min-h-screen flex items-center justify-center bg-gray-900 text-white">
-    <div class="w-full max-w-md bg-gray-800 rounded-lg shadow-lg p-8">
+  <div class="min-h-screen flex bg-gray-900 text-white">
+    <div class="relative hidden md:flex w-1/2 items-center justify-center">
+      <img
+        src="https://images.unsplash.com/photo-1522202176988-66273c2fd55f?auto=format&fit=crop&w=600&q=60"
+        alt="Background"
+        class="object-cover w-full h-full"
+      />
+      <span
+        class="material-symbols-outlined absolute text-white text-9xl"
+      >early_on</span>
+    </div>
+    <div class="flex flex-1 items-center justify-center">
+      <div class="w-full max-w-md bg-gray-800 rounded-lg shadow-lg p-8 animate-pulse-glow">
       <h2 class="text-2xl font-bold mb-6 text-center">Sign in</h2>
       <form class="space-y-4" @submit.prevent="loginWithEmail">
         <input v-model="email" type="email" placeholder="Email" class="w-full p-2 rounded bg-gray-700 placeholder-gray-400" />
@@ -8,9 +19,16 @@
         <button type="submit" class="w-full py-2 bg-blue-500 rounded">Sign in</button>
       </form>
       <div class="mt-4 flex flex-col gap-2">
-        <button class="w-full py-2 bg-red-600 rounded" @click="loginGoogle">Sign in with Google</button>
-        <button class="w-full py-2 bg-gray-700 rounded" @click="loginGithub">Sign in with Github</button>
+        <button class="w-full py-2 bg-red-600 rounded flex items-center justify-center gap-2" @click="loginGoogle">
+          <img src="https://www.svgrepo.com/show/475656/google-color.svg" alt="Google" class="w-5 h-5" />
+          Sign in with Google
+        </button>
+        <button class="w-full py-2 bg-gray-700 rounded flex items-center justify-center gap-2" @click="loginGithub">
+          <img src="https://www.svgrepo.com/show/475661/github-color.svg" alt="Github" class="w-5 h-5" />
+          Sign in with Github
+        </button>
       </div>
+    </div>
     </div>
   </div>
 </template>

--- a/app/pages/login.vue
+++ b/app/pages/login.vue
@@ -1,34 +1,34 @@
 <template>
-  <div class="min-h-screen flex bg-gray-900 text-white">
-    <div class="relative hidden md:flex w-1/2 items-center justify-center">
-      <img
-        src="https://images.unsplash.com/photo-1522202176988-66273c2fd55f?auto=format&fit=crop&w=600&q=60"
-        alt="Background"
-        class="object-cover w-full h-full"
-      />
-      <span
-        class="material-symbols-outlined absolute text-white text-9xl"
-      >early_on</span>
-    </div>
-    <div class="flex flex-1 items-center justify-center">
-      <div class="w-full max-w-md bg-gray-800 rounded-lg shadow-lg p-8 animate-pulse-glow">
-      <h2 class="text-2xl font-bold mb-6 text-center">Sign in</h2>
-      <form class="space-y-4" @submit.prevent="loginWithEmail">
-        <input v-model="email" type="email" placeholder="Email" class="w-full p-2 rounded bg-gray-700 placeholder-gray-400" />
-        <input v-model="password" type="password" placeholder="Password" class="w-full p-2 rounded bg-gray-700 placeholder-gray-400" />
-        <button type="submit" class="w-full py-2 bg-blue-500 rounded">Sign in</button>
-      </form>
-      <div class="mt-4 flex flex-col gap-2">
-        <button class="w-full py-2 bg-red-600 rounded flex items-center justify-center gap-2" @click="loginGoogle">
-          <img src="https://www.svgrepo.com/show/475656/google-color.svg" alt="Google" class="w-5 h-5" />
-          Sign in with Google
-        </button>
-        <button class="w-full py-2 bg-gray-700 rounded flex items-center justify-center gap-2" @click="loginGithub">
-          <img src="https://www.svgrepo.com/show/475661/github-color.svg" alt="Github" class="w-5 h-5" />
-          Sign in with Github
-        </button>
+  <div class="min-h-screen flex items-center justify-center bg-gray-900 text-white">
+    <div class="w-full max-w-md bg-gray-800 rounded-lg shadow-lg p-8 animate-pulse-glow flex">
+      <div class="relative hidden md:block w-1/2 pr-6">
+        <img
+          src="https://images.unsplash.com/photo-1522202176988-66273c2fd55f?auto=format&fit=crop&w=300&q=60"
+          alt="Background"
+          class="object-cover w-full h-full rounded"
+        />
+        <span
+          class="material-symbols-outlined absolute inset-0 flex items-center justify-center text-white text-6xl"
+        >early_on</span>
       </div>
-    </div>
+      <div class="flex-1">
+        <h2 class="text-2xl font-bold mb-6 text-center">Sign in</h2>
+        <form class="space-y-4" @submit.prevent="loginWithEmail">
+          <input v-model="email" type="email" placeholder="Email" class="w-full p-2 rounded bg-gray-700 placeholder-gray-400" />
+          <input v-model="password" type="password" placeholder="Password" class="w-full p-2 rounded bg-gray-700 placeholder-gray-400" />
+          <button type="submit" class="w-full py-2 bg-blue-500 rounded">Sign in</button>
+        </form>
+        <div class="mt-4 flex flex-col gap-2">
+          <button class="w-full py-2 bg-red-600 rounded flex items-center justify-center gap-2" @click="loginGoogle">
+            <img src="https://www.svgrepo.com/show/475656/google-color.svg" alt="Google" class="w-5 h-5" />
+            Sign in with Google
+          </button>
+          <button class="w-full py-2 bg-gray-700 rounded flex items-center justify-center gap-2" @click="loginGithub">
+            <img src="https://www.svgrepo.com/show/475661/github-color.svg" alt="Github" class="w-5 h-5" />
+            Sign in with Github
+          </button>
+        </div>
+      </div>
     </div>
   </div>
 </template>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,8 +1,6 @@
 module.exports = {
   content: [
-    './app.vue',
-    './pages/**/*.{vue,ts}',
-    './components/**/*.{vue,ts}'
+    './app/**/*.{vue,ts}'
   ],
   theme: {
     extend: {
@@ -10,7 +8,16 @@ module.exports = {
         brand: 'var(--brand)',
         primary: 'var(--primary)',
         secondary: 'var(--secondary)',
+      },
+      keyframes: {
+        'pulse-glow': {
+          '0%, 100%': { boxShadow: '0 0 15px rgba(59,130,246,0.4)' },
+          '50%': { boxShadow: '0 0 30px rgba(59,130,246,0.8)' }
+        }
+      },
+      animation: {
+        'pulse-glow': 'pulse-glow 3s ease-in-out infinite'
       }
     }
   }
-}
+} 

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -20,4 +20,4 @@ module.exports = {
       }
     }
   }
-} 
+}


### PR DESCRIPTION
## Summary
- add left side image with Early On icon on login page
- include Google and GitHub logos on auth buttons
- animate login card with soft pulsating glow

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a149cebbc4832eb720208f133c9682