### PR TITLE
feat: add delete task confirmation modal

### DIFF
--- a/app/app.vue
+++ b/app/app.vue
@@ -69,6 +69,7 @@
         <DeleteCategoryModal />
         <CategoryModal />
         <TaskModal />
+        <DeleteTaskModal />
     </div>
   </template>
 </template>
@@ -84,6 +85,7 @@ import DeleteCategoryModal from './components/DeleteCategoryModal.vue'
 import CategoryList from './components/CategoryList.vue'
 import CategoryModal from './components/CategoryModal.vue'
 import TaskModal from './components/TaskModal.vue'
+import DeleteTaskModal from './components/DeleteTaskModal.vue'
 import { textColor } from './utils/color'
 
 interface Todo {

--- a/app/components/DeleteTaskModal.vue
+++ b/app/components/DeleteTaskModal.vue
@@ -1,0 +1,46 @@
+<template>
+  <div
+    v-if="showModal"
+    class="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-[3000]"
+  >
+    <div class="bg-white p-4 rounded shadow w-80 text-black">
+      <h4 class="text-lg font-semibold mb-4">Delete task?</h4>
+      <div class="flex justify-end gap-2">
+        <button @click="cancelDelete" class="px-3 py-1 bg-gray-200 rounded">Cancel</button>
+        <button @click="deleteTask" class="px-3 py-1 bg-red-500 text-white rounded">Delete</button>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { useFirebaseApp } from 'vuefire'
+import { getFirestore, doc, deleteDoc } from 'firebase/firestore'
+
+interface Todo {
+  id?: string
+  title: string
+  order: number
+  date: string | null
+  done: boolean
+  categoryId: string | null
+}
+
+const user = useState<{ uid: string } | null>('user', () => null)
+const taskToDelete = useState<Todo | null>('taskToDelete', () => null)
+const showModal = useState<boolean>('showDeleteTaskModal', () => false)
+
+const app = useFirebaseApp()
+const db = getFirestore(app)
+
+const cancelDelete = () => {
+  showModal.value = false
+  taskToDelete.value = null
+}
+
+const deleteTask = async () => {
+  if (!user.value || !taskToDelete.value?.id) return
+  await deleteDoc(doc(db, 'users', user.value.uid, 'todos', taskToDelete.value.id))
+  cancelDelete()
+}
+</script>

--- a/app/components/TodoList.vue
+++ b/app/components/TodoList.vue
@@ -110,7 +110,7 @@
               <button @click="openEdit(t)" aria-label="Edit task">
                 <span class="material-symbols-outlined">edit</span>
               </button>
-              <button class="text-red-500" @click="deleteTask(t)" aria-label="Remove task">
+              <button class="text-red-500" @click="confirmDelete(t)" aria-label="Remove task">
                 <span class="material-symbols-outlined">delete</span>
               </button>
             </div>
@@ -156,7 +156,7 @@
               <button @click="openEdit(t)" aria-label="Edit task">
                 <span class="material-symbols-outlined">edit</span>
               </button>
-              <button class="text-red-500" @click="deleteTask(t)" aria-label="Remove task">
+              <button class="text-red-500" @click="confirmDelete(t)" aria-label="Remove task">
                 <span class="material-symbols-outlined">delete</span>
               </button>
             </div>
@@ -357,6 +357,14 @@ const openEdit = (t: Todo) => {
   showTaskModal.value = true
 }
 
+const taskToDelete = useState<Todo | null>('taskToDelete', () => null)
+const showDeleteTaskModal = useState<boolean>('showDeleteTaskModal', () => false)
+
+const confirmDelete = (t: Todo) => {
+  taskToDelete.value = t
+  showDeleteTaskModal.value = true
+}
+
 const add = async () => {
   const s = title.value.trim()
   if (!s || !user.value) return
@@ -371,12 +379,6 @@ const add = async () => {
   })
   noDate.value = false
 }
-
-const deleteTask = async (t: Todo) => {
-  if (!user.value) return
-  if (t?.id) await deleteDoc(doc(db, 'users', user.value.uid, 'todos', t.id))
-}
-
 const toggle = async (t: Todo) => {
   if (!user.value || !t.id) return
   await updateDoc(doc(db, 'users', user.value.uid, 'todos', t.id), {


### PR DESCRIPTION
## Summary
- add DeleteTaskModal component to confirm task deletions
- wire up TodoList to open confirmation modal before removing a task
- register DeleteTaskModal in app layout

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a8b47779c0832e86187df590db1576