### PR TITLE
fix: persist Firebase user session

### DIFF
--- a/app/plugins/auth.client.ts
+++ b/app/plugins/auth.client.ts
@@ -1,16 +1,28 @@
 import { defineNuxtPlugin } from '#app'
 import { useFirebaseApp } from 'vuefire'
-import { getAuth, onAuthStateChanged } from 'firebase/auth'
+import { getAuth, onAuthStateChanged, setPersistence, browserLocalPersistence } from 'firebase/auth'
 
-export default defineNuxtPlugin(() => {
+export default defineNuxtPlugin(async () => {
   const app = useFirebaseApp()
   const auth = getAuth(app)
-  const user = useState<{uid:string;displayName:string|null;photoURL:string|null}|null>('user', () => null)
+  await setPersistence(auth, browserLocalPersistence)
 
-  const u = auth.currentUser
-  user.value = u ? { uid: u.uid, displayName: u.displayName, photoURL: u.photoURL } : null
+  const user = useState<{
+    uid: string
+    displayName: string | null
+    photoURL: string | null
+  } | null>('user', () => null)
 
-  onAuthStateChanged(auth, (newUser) => {
-    user.value = newUser ? { uid: newUser.uid, displayName: newUser.displayName, photoURL: newUser.photoURL } : null
+  await new Promise<void>((resolve) => {
+    onAuthStateChanged(auth, (newUser) => {
+      user.value = newUser
+        ? {
+            uid: newUser.uid,
+            displayName: newUser.displayName,
+            photoURL: newUser.photoURL
+          }
+        : null
+      resolve()
+    })
   })
 })


### PR DESCRIPTION
## Summary
- ensure Firebase auth persistence using browser storage
- await initial auth state to populate user in route middleware

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a9b77d3884832e86dabd4895fc01d9